### PR TITLE
Add support for the --isolatedModules flag in deno's default setting.

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,6 @@
-export { Either, Left, Right, isLeft, isRight } from "./lib/either/either.deno.ts";
-export { Option, Some, None, isSome, isNone } from "./lib/option/option.deno.ts";
-export { Result, Ok, Err, isOk, isErr } from "./lib/result/result.deno.ts";
+export { Left, Right, isLeft, isRight } from "./lib/either/either.deno.ts";
+export type { Either } from "./lib/either/either.deno.ts";
+export { Some, None, isSome, isNone } from "./lib/option/option.deno.ts";
+export type { Option } from "./lib/option/option.deno.ts";
+export { Ok, Err, isOk, isErr } from "./lib/result/result.deno.ts";
+export type { Result } from "./lib/result/result.deno.ts";


### PR DESCRIPTION
In Deno, since version 1.4, the ----isolatedModules flag is forced to be applied.